### PR TITLE
Add FSQ dequantize logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,8 @@ dependencies = [
 [[package]]
 name = "candle-core"
 version = "0.7.1"
-source = "git+https://github.com/huggingface/candle?rev=d01207dbf3fb0ad614e7915c8f5706fbc09902fb#d01207dbf3fb0ad614e7915c8f5706fbc09902fb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eefd88b58cb1641a6245bfc6aa79032da2fac39da7c3eec1a08da5f16a739a38"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -265,7 +266,8 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.7.1"
-source = "git+https://github.com/huggingface/candle?rev=d01207dbf3fb0ad614e7915c8f5706fbc09902fb#d01207dbf3fb0ad614e7915c8f5706fbc09902fb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a66b755bdb5c3885647188d245e58787710012d8b20308a6e3a068c085630e"
 dependencies = [
  "bindgen_cuda",
 ]
@@ -273,7 +275,8 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.7.1"
-source = "git+https://github.com/huggingface/candle?rev=d01207dbf3fb0ad614e7915c8f5706fbc09902fb#d01207dbf3fb0ad614e7915c8f5706fbc09902fb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac8e8e2f3d525714c1a8931f0c52212e99c03d07aefd6c870c3be8b83d136e6d"
 dependencies = [
  "metal",
  "once_cell",
@@ -299,7 +302,8 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.7.1"
-source = "git+https://github.com/huggingface/candle?rev=d01207dbf3fb0ad614e7915c8f5706fbc09902fb#d01207dbf3fb0ad614e7915c8f5706fbc09902fb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80a0c5302dd952d02987435bf27c8564d9f681095e69bbb851102a9d6898f70b"
 dependencies = [
  "candle-core 0.7.1",
  "candle-metal-kernels",
@@ -315,7 +319,8 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.7.1"
-source = "git+https://github.com/huggingface/candle?rev=d01207dbf3fb0ad614e7915c8f5706fbc09902fb#d01207dbf3fb0ad614e7915c8f5706fbc09902fb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4faabe4a2993ecb312ab99b4b6b3f18304d4930d35f84585b8bb61b564e3bfb6"
 dependencies = [
  "byteorder",
  "candle-core 0.7.1",
@@ -697,6 +702,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_yaml",
  "symphonia",
  "thiserror",
  "tokenizers",
@@ -1278,7 +1284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2168,6 +2174,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,6 +2709,12 @@ name = "unindent"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/fish_speech_core/Cargo.toml
+++ b/fish_speech_core/Cargo.toml
@@ -14,10 +14,9 @@ metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]
 [dependencies]
 anyhow = "1.0.86"
 byteorder = "1.5.0"
-# TODO: Fix when 0.7.1 is released to Cargo
-candle-core = { git = "https://github.com/huggingface/candle", rev = "d01207dbf3fb0ad614e7915c8f5706fbc09902fb" }
-candle-nn = { git = "https://github.com/huggingface/candle", rev = "d01207dbf3fb0ad614e7915c8f5706fbc09902fb" }
-candle-transformers = { git = "https://github.com/huggingface/candle", rev = "d01207dbf3fb0ad614e7915c8f5706fbc09902fb" }
+candle-core = "0.7.1"
+candle-nn = "0.7.1"
+candle-transformers = "0.7.1"
 clap = { version = "4.5.16", features = ["derive"] }
 hf-hub = "0.3.2"
 indicatif = "0.17.8"
@@ -25,6 +24,7 @@ rand = "0.8.5"
 regex = "1.10.6"
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.127"
+serde_yaml = "0.9.34"
 symphonia = "0.5.4"
 thiserror = "1.0.63"
 tokenizers = "0.20.0"

--- a/fish_speech_core/lib/models/vqgan/decoder.rs
+++ b/fish_speech_core/lib/models/vqgan/decoder.rs
@@ -1,0 +1,64 @@
+use candle_core::{Device, Result, Tensor, D};
+use candle_nn::VarBuilder;
+
+use super::hifi_gan::HiFiGAN;
+use super::quantizer::DownsampleFiniteScalarQuantizer;
+use super::utils::config::FireflyConfig;
+
+fn sequence_mask(lengths: &Tensor, max_length: Option<u32>, device: &Device) -> Result<Tensor> {
+    let max_length = max_length.unwrap_or(lengths.max_keepdim(D::Minus1)?.to_scalar::<u32>()?);
+    let x = Tensor::arange(0 as u32, max_length as u32, device)?.unsqueeze(0)?;
+    x.broadcast_lt(&lengths.unsqueeze(1)?)
+}
+
+pub struct FireflyDecoder {
+    quantizer: DownsampleFiniteScalarQuantizer,
+    head: HiFiGAN,
+    cfg: FireflyConfig,
+}
+
+impl FireflyDecoder {
+    /// TODO: make this configurable!
+    pub fn load(vb: &VarBuilder, cfg: &FireflyConfig) -> Result<Self> {
+        let quantizer = DownsampleFiniteScalarQuantizer::load(vb.pp("quantizer"), &cfg.quantizer)?;
+        let head = HiFiGAN::load(vb.pp("head"), &cfg.head)?;
+
+        Ok(Self {
+            quantizer,
+            head,
+            cfg: cfg.clone(),
+        })
+    }
+
+    pub fn forward(&self, indices: &Tensor, feature_lengths: &Tensor) -> Result<Tensor> {
+        let factor = self
+            .quantizer
+            .downsample_factor
+            .clone()
+            .into_iter()
+            .reduce(|acc, e| acc * e)
+            .unwrap_or(1);
+
+        let mel_masks = sequence_mask(
+            &(feature_lengths * (factor as f64))?,
+            Some((indices.dim(2)? * factor) as u32),
+            indices.device(),
+        )?;
+        // TODO: Figure out what dtype it needs to be
+        let mel_masks_float_conv = mel_masks.unsqueeze(1)?;
+
+        let audio_masks = sequence_mask(
+            &((feature_lengths * (factor as f64))? * self.cfg.spec_transform.hop_length as f64)?,
+            Some((indices.dim(2)? * factor * self.cfg.spec_transform.hop_length) as u32),
+            indices.device(),
+        )?;
+        let audio_masks_float_conv = audio_masks.unsqueeze(1)?;
+
+        let z = self
+            .quantizer
+            .decode(indices)?
+            .broadcast_mul(&mel_masks_float_conv);
+
+        z
+    }
+}

--- a/fish_speech_core/lib/models/vqgan/encoder.rs
+++ b/fish_speech_core/lib/models/vqgan/encoder.rs
@@ -1,0 +1,40 @@
+use super::convnext::{ConvNeXtEncoder, ConvNeXtEncoderConfig};
+use super::quantizer::DownsampleFiniteScalarQuantizer;
+use super::utils::config::FireflyConfig;
+use anyhow::Result as AnyhowResult;
+use candle_core::{Result, Tensor};
+use candle_nn::{Module, VarBuilder};
+
+pub struct FireflyEncoder {
+    backbone: ConvNeXtEncoder,
+    quantizer: DownsampleFiniteScalarQuantizer,
+}
+
+impl FireflyEncoder {
+    pub fn load(vb: VarBuilder, cfg: &FireflyConfig) -> AnyhowResult<Self> {
+        // TODO: This will have to be fixed w/ rest of config
+        let backbone = ConvNeXtEncoder::load(
+            vb.pp("backbone"),
+            &ConvNeXtEncoderConfig {
+                input_channels: cfg.backbone.input_channels,
+                dims: cfg.backbone.dims.to_vec(),
+                depths: cfg.backbone.depths.to_vec(),
+                kernel_size: cfg.backbone.kernel_size,
+                ..Default::default()
+            },
+        )?;
+        let quantizer = DownsampleFiniteScalarQuantizer::load(vb.pp("quantizer"), &cfg.quantizer)?;
+        Ok(Self {
+            backbone,
+            quantizer,
+        })
+    }
+
+    /// Unlike upstream implementation, requires MEL binning beforehand
+    pub fn encode(&self, mel: &Tensor) -> Result<Tensor> {
+        // mel.write_npy("spec_transform.npy")?;
+        let encoded_features = self.backbone.forward(&mel)?;
+        // encoded_features.write_npy("backbone.npy")?;
+        self.quantizer.encode(&encoded_features)
+    }
+}

--- a/fish_speech_core/lib/models/vqgan/fsq.rs
+++ b/fish_speech_core/lib/models/vqgan/fsq.rs
@@ -69,7 +69,8 @@ impl FSQ {
     }
 
     pub fn bound(&self, z: &Tensor) -> Result<Tensor> {
-        let levels_sub_1 = self.levels.sub(&Tensor::ones_like(&self.levels)?)?;
+        // let levels_sub_1 = self.levels.sub(&Tensor::ones_like(&self.levels)?)?;
+        let levels_sub_1 = (self.levels.clone() - 1f64)?;
         let half_l = ((levels_sub_1 * 1.001 as f64)? / 2.0 as f64)?;
 
         let remainder = remainder_float(&self.levels, 2.0)?;

--- a/fish_speech_core/lib/models/vqgan/fsq.rs
+++ b/fish_speech_core/lib/models/vqgan/fsq.rs
@@ -27,8 +27,8 @@ fn atanh(x: &Tensor) -> Result<Tensor> {
 
 // This is also not implemented as a binary op. Don't ask me why
 fn remainder(x: &Tensor, y: &Tensor) -> Result<Tensor> {
-    let quotient = x.div(y)?.floor()?;
-    x.sub(&quotient.mul(y)?)
+    let quotient = x.broadcast_div(y)?.floor()?;
+    x.broadcast_sub(&quotient.broadcast_mul(y)?)
 }
 
 // This is also not implemented as a binary op. Don't ask me why
@@ -121,7 +121,7 @@ impl FSQ {
 
     fn _scale_and_shift_inverse(&self, zhat: &Tensor) -> Result<Tensor> {
         let half_width = (self.levels.clone() / 2.0 as f64)?.floor()?;
-        zhat.broadcast_sub(&half_width)?.div(&half_width)
+        zhat.broadcast_sub(&half_width)?.broadcast_div(&half_width)
     }
 
     pub fn codes_to_indices(&self, zhat: &Tensor) -> Result<Tensor> {
@@ -139,14 +139,9 @@ impl FSQ {
 
     pub fn indices_to_level_indices(&self, indices: &Tensor) -> Result<Tensor> {
         let indices = indices.unsqueeze(D::Minus1)?;
-        let codes_non_centered = indices
-            .div(&self.basis.unsqueeze(0)?.unsqueeze(0)?)?
-            .floor()?;
+        let codes_non_centered = indices.broadcast_div(&self.basis)?.floor()?;
 
-        let codes_non_centered = remainder(
-            &codes_non_centered,
-            &self.levels.unsqueeze(0)?.unsqueeze(0)?,
-        )?;
+        let codes_non_centered = remainder(&codes_non_centered, &self.levels)?;
         Ok(codes_non_centered)
     }
 
@@ -161,7 +156,8 @@ impl FSQ {
     }
 
     pub fn implicit_codebook(&self) -> Result<Tensor> {
-        let indices = Tensor::arange(0, self.codebook_size() as i64, self.levels.device())?;
+        let indices = Tensor::arange(0, self.codebook_size() as i64, self.levels.device())?
+            .to_dtype(DType::F32)?;
         self.indices_to_codes(&indices)
     }
 }

--- a/fish_speech_core/lib/models/vqgan/hifi_gan.rs
+++ b/fish_speech_core/lib/models/vqgan/hifi_gan.rs
@@ -6,6 +6,6 @@ pub struct HiFiGAN {}
 
 impl HiFiGAN {
     pub fn load(vb: VarBuilder, cfg: &HiFiGANConfig) -> Result<Self> {
-        Err(candle_core::Error::Msg("Not yet implemented".into()))
+        Ok(Self {})
     }
 }

--- a/fish_speech_core/lib/models/vqgan/hifi_gan.rs
+++ b/fish_speech_core/lib/models/vqgan/hifi_gan.rs
@@ -1,0 +1,11 @@
+use super::utils::config::HiFiGANConfig;
+use candle_core::Result;
+use candle_nn::{Conv1d, VarBuilder};
+
+pub struct HiFiGAN {}
+
+impl HiFiGAN {
+    pub fn load(vb: VarBuilder, cfg: &HiFiGANConfig) -> Result<Self> {
+        Err(candle_core::Error::Msg("Not yet implemented".into()))
+    }
+}

--- a/fish_speech_core/lib/models/vqgan/mod.rs
+++ b/fish_speech_core/lib/models/vqgan/mod.rs
@@ -1,71 +1,8 @@
 pub mod convnext;
+pub mod decoder;
+pub mod encoder;
 mod fsq;
 mod grouped_residual_fsq;
+mod hifi_gan;
 pub mod quantizer;
-
-use anyhow::Result as AnyhowResult;
-use candle_core::{Result, Tensor};
-use candle_nn::{Module, VarBuilder};
-use convnext::{ConvNeXtEncoder, ConvNeXtEncoderConfig};
-use quantizer::{DownsampleFSQConfig, DownsampleFiniteScalarQuantizer};
-
-#[derive(Clone)]
-/// Incomplete. Will go back and fix it soon
-pub struct Config {
-    input_channels: usize,
-    depths: [usize; 4],
-    dims: [usize; 4],
-    kernel_size: usize,
-}
-
-impl Config {
-    /// Config from Fish Speech 1.2 SFT
-    pub fn fish_1_2() -> Self {
-        Self {
-            input_channels: 160,
-            depths: [3, 3, 9, 3],
-            dims: [128, 256, 384, 512],
-            // drop_path_rate: 0.2,
-            kernel_size: 7,
-        }
-    }
-}
-
-pub struct FireflyArchitecture {
-    backbone: ConvNeXtEncoder,
-    quantizer: DownsampleFiniteScalarQuantizer,
-}
-
-impl FireflyArchitecture {
-    pub fn load(vb: VarBuilder) -> AnyhowResult<Self> {
-        let config = Config::fish_1_2();
-        // TODO: This will have to be fixed w/ rest of config
-        let backbone = ConvNeXtEncoder::load(
-            vb.pp("backbone"),
-            &ConvNeXtEncoderConfig {
-                input_channels: config.input_channels,
-                dims: config.dims.to_vec(),
-                depths: config.depths.to_vec(),
-                kernel_size: config.kernel_size,
-                ..Default::default()
-            },
-        )?;
-        let quantizer = DownsampleFiniteScalarQuantizer::load(
-            vb.pp("quantizer"),
-            // TODO: Parameterize this
-            DownsampleFSQConfig::firefly_1_2(),
-        )?;
-        Ok(Self {
-            backbone,
-            quantizer,
-        })
-    }
-
-    /// Unlike upstream implementation, requires MEL binning beforehand
-    pub fn encode(&self, mel: &Tensor) -> Result<Tensor> {
-        // mel.write_npy("spec_transform.npy")?;
-        let encoded_features = self.backbone.forward(&mel)?;
-        // encoded_features.write_npy("backbone.npy")?;
-        self.quantizer.encode(&encoded_features)
-    }
-}
+pub mod utils;

--- a/fish_speech_core/lib/models/vqgan/quantizer.rs
+++ b/fish_speech_core/lib/models/vqgan/quantizer.rs
@@ -1,44 +1,22 @@
 use super::convnext::{ConvNeXtBlock, ConvNeXtBlockConfig};
 use super::grouped_residual_fsq::{GroupedResidualFSQ, GroupedResidualFSQConfig};
+use super::utils::config::DownsampleFSQConfig;
 use candle_core::{Result, Tensor};
 use candle_nn::{
     seq, Conv1d, Conv1dConfig, ConvTranspose1d, ConvTranspose1dConfig, Module, Sequential,
     VarBuilder,
 };
 
-// https://github.com/fishaudio/fish-speech/blob/9e2f5e6b3a382849b8ee54da10d6a68bbd913f4d/fish_speech/models/vqgan/modules/fsq.py#L4
-
-pub struct DownsampleFSQConfig {
-    input_dim: usize,
-    n_codebooks: usize,
-    n_groups: usize,
-    levels: Vec<u32>,
-    downsample_factor: Vec<usize>,
-    downsample_dims: Option<Vec<usize>>,
-}
-
-impl DownsampleFSQConfig {
-    pub fn firefly_1_2() -> Self {
-        Self {
-            input_dim: 512,
-            n_groups: 4,
-            n_codebooks: 1,
-            levels: vec![8, 5, 5, 5],
-            downsample_factor: vec![2],
-            downsample_dims: None,
-        }
-    }
-}
-
 pub struct DownsampleFiniteScalarQuantizer {
     downsample: Sequential,
-    upsample: Sequential,
+    _upsample: Sequential,
     residual_fsq: GroupedResidualFSQ,
+    pub downsample_factor: Vec<usize>,
 }
 
 impl DownsampleFiniteScalarQuantizer {
-    pub fn load(vb: VarBuilder, config: DownsampleFSQConfig) -> Result<Self> {
-        let all_dims: Vec<usize> = if let Some(downsample_dims) = config.downsample_dims {
+    pub fn load(vb: VarBuilder, config: &DownsampleFSQConfig) -> Result<Self> {
+        let all_dims: Vec<usize> = if let Some(downsample_dims) = config.downsample_dims.clone() {
             std::iter::once(config.input_dim)
                 .chain(downsample_dims.into_iter())
                 .collect()
@@ -52,7 +30,7 @@ impl DownsampleFiniteScalarQuantizer {
             vb.pp("residual_fsq"),
             &GroupedResidualFSQConfig {
                 dim: *all_dims.last().unwrap(),
-                levels: config.levels,
+                levels: config.levels.clone(),
                 num_quantizers: config.n_codebooks,
                 groups: config.n_groups,
             },
@@ -111,7 +89,8 @@ impl DownsampleFiniteScalarQuantizer {
         Ok(Self {
             residual_fsq,
             downsample,
-            upsample,
+            downsample_factor: config.downsample_factor.clone(),
+            _upsample: upsample,
         })
     }
 
@@ -135,8 +114,21 @@ impl DownsampleFiniteScalarQuantizer {
         Ok(indices)
     }
 
-    pub fn upsample(self, z: &Tensor) -> Result<Tensor> {
+    pub fn upsample(&self, z: &Tensor) -> Result<Tensor> {
         // TODO: Residual_FSQ
-        self.upsample.forward(z)
+        self._upsample.forward(z)
+    }
+
+    pub fn decode(&self, indices: &Tensor) -> Result<Tensor> {
+        // b (gr) l -> g b l r
+        let (b, gr, l) = indices.dims3()?;
+        let indices = indices.reshape((
+            self.residual_fsq.groups,
+            b,
+            l,
+            gr / self.residual_fsq.groups,
+        ))?;
+        let z_q = self.residual_fsq.get_output_from_indices(&indices)?;
+        self.upsample(&z_q.t()?)
     }
 }

--- a/fish_speech_core/lib/models/vqgan/quantizer.rs
+++ b/fish_speech_core/lib/models/vqgan/quantizer.rs
@@ -129,6 +129,7 @@ impl DownsampleFiniteScalarQuantizer {
             gr / self.residual_fsq.groups,
         ))?;
         let z_q = self.residual_fsq.get_output_from_indices(&indices)?;
-        self.upsample(&z_q.t()?)
+        println!("z_q shape: {:?}", z_q.shape());
+        self.upsample(&z_q.transpose(1, 2)?)
     }
 }

--- a/fish_speech_core/lib/models/vqgan/utils/config.rs
+++ b/fish_speech_core/lib/models/vqgan/utils/config.rs
@@ -1,0 +1,119 @@
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SpecTransformConfig {
+    pub sample_rate: usize,
+    pub n_mels: usize,
+    pub n_fft: usize,
+    pub hop_length: usize,
+    pub win_length: usize,
+}
+
+impl SpecTransformConfig {
+    pub fn fish_1_2() -> Self {
+        Self {
+            sample_rate: 44100,
+            n_mels: 160,
+            n_fft: 2048,
+            hop_length: 512,
+            win_length: 2048,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BackboneConfig {
+    pub input_channels: usize,
+    pub depths: [usize; 4],
+    pub dims: [usize; 4],
+    pub kernel_size: usize,
+}
+
+impl BackboneConfig {
+    /// Config from Fish Speech 1.2 SFT
+    pub fn fish_1_2() -> Self {
+        Self {
+            input_channels: 160,
+            depths: [3, 3, 9, 3],
+            dims: [128, 256, 384, 512],
+            // drop_path_rate: 0.2,
+            kernel_size: 7,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HiFiGANConfig {
+    pub hop_length: usize,
+    pub upsample_rates: Vec<usize>,
+    pub upsample_kernel_sizes: Vec<usize>,
+    pub resblock_kernel_sizes: Vec<usize>,
+    pub resblock_dilation_sizes: Vec<Vec<usize>>,
+    pub num_mels: usize,
+    pub upsample_initial_channel: usize,
+    pub use_template: bool,
+    pub pre_conv_kernel_size: usize,
+    pub post_conv_kernel_size: usize,
+}
+
+impl HiFiGANConfig {
+    pub fn fish_1_2() -> Self {
+        Self {
+            hop_length: 512,
+            upsample_rates: vec![8, 8, 2, 2, 2],
+            upsample_kernel_sizes: vec![16, 16, 4, 4, 4],
+            resblock_kernel_sizes: vec![3, 7, 11],
+            resblock_dilation_sizes: vec![vec![1, 3, 5], vec![1, 3, 5], vec![1, 3, 5]],
+            num_mels: 512,
+            upsample_initial_channel: 512,
+            use_template: false,
+            pre_conv_kernel_size: 13,
+            post_conv_kernel_size: 13,
+        }
+    }
+}
+
+// https://github.com/fishaudio/fish-speech/blob/9e2f5e6b3a382849b8ee54da10d6a68bbd913f4d/fish_speech/models/vqgan/modules/fsq.py#L4
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DownsampleFSQConfig {
+    pub input_dim: usize,
+    pub n_codebooks: usize,
+    pub n_groups: usize,
+    pub levels: Vec<u32>,
+    pub downsample_factor: Vec<usize>,
+    pub downsample_dims: Option<Vec<usize>>,
+}
+
+impl DownsampleFSQConfig {
+    pub fn firefly_1_2() -> Self {
+        Self {
+            input_dim: 512,
+            n_groups: 4,
+            n_codebooks: 1,
+            levels: vec![8, 5, 5, 5],
+            downsample_factor: vec![2],
+            downsample_dims: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FireflyConfig {
+    pub spec_transform: SpecTransformConfig,
+    pub backbone: BackboneConfig,
+    pub head: HiFiGANConfig,
+    pub quantizer: DownsampleFSQConfig,
+}
+
+impl FireflyConfig {
+    pub fn fish_speech_1_2() -> Self {
+        Self {
+            spec_transform: SpecTransformConfig::fish_1_2(),
+            backbone: BackboneConfig::fish_1_2(),
+            head: HiFiGANConfig::fish_1_2(),
+            quantizer: DownsampleFSQConfig::firefly_1_2(),
+        }
+    }
+}

--- a/fish_speech_core/lib/models/vqgan/utils/mod.rs
+++ b/fish_speech_core/lib/models/vqgan/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod config;

--- a/fish_speech_core/src/bin/vocoder.rs
+++ b/fish_speech_core/src/bin/vocoder.rs
@@ -1,0 +1,14 @@
+use anyhow::Result;
+use candle_core::{DType, Device, Tensor};
+use candle_nn::VarBuilder;
+
+fn main() -> Result<()> {
+    let input = Tensor::read_npy("out.npy")?;
+    // TODO: Support BF16
+    let dtype = DType::F32;
+    // TODO: Support hardware acceleration;
+    let device = Device::Cpu;
+    let vb = VarBuilder::from_pth("checkpoints/fish-speech-1.2-sft", dtype, &device)?;
+
+    Ok(())
+}

--- a/fish_speech_core/src/bin/vocoder.rs
+++ b/fish_speech_core/src/bin/vocoder.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
-use candle_core::{DType, Device, Tensor};
+use candle_core::{DType, Device, Tensor, D};
 use candle_nn::VarBuilder;
+use fish_speech_core::models::vqgan::decoder::FireflyDecoder;
+use fish_speech_core::models::vqgan::utils::config::FireflyConfig;
 
 fn main() -> Result<()> {
     let input = Tensor::read_npy("out.npy")?;
@@ -8,7 +10,20 @@ fn main() -> Result<()> {
     let dtype = DType::F32;
     // TODO: Support hardware acceleration;
     let device = Device::Cpu;
-    let vb = VarBuilder::from_pth("checkpoints/fish-speech-1.2-sft", dtype, &device)?;
+    let vb = VarBuilder::from_pth(
+        "checkpoints/fish-speech-1.2-sft/firefly-gan-vq-fsq-4x1024-42hz-generator.pth",
+        dtype,
+        &device,
+    )?;
+
+    // TODO: Support Fish 1.4
+    println!("Loading model");
+    let model = FireflyDecoder::load(&vb, &FireflyConfig::fish_speech_1_2())?;
+    println!("Model loaded");
+    let feature_lengths = Tensor::from_slice(&[input.dim(D::Minus1)? as u32], 1, &device)?;
+    let fake_audios = model.decode(&input.unsqueeze(0)?, &feature_lengths)?;
+    // println!("Fake audios: {:?}", fake_audios.is_ok());
+    fake_audios.write_npy("quantizer_decode_rust.npy")?;
 
     Ok(())
 }

--- a/fish_speech_core/src/main.rs
+++ b/fish_speech_core/src/main.rs
@@ -3,7 +3,8 @@ use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use clap::{Parser, ValueHint};
 use fish_speech_core::audio as torchaudio;
-use fish_speech_core::models::vqgan::FireflyArchitecture;
+use fish_speech_core::models::vqgan::encoder::FireflyEncoder;
+use fish_speech_core::models::vqgan::utils::config::FireflyConfig;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -50,7 +51,7 @@ fn main() -> Result<()> {
 
     // NOTE: Not using audio for now
     let override_mel = Tensor::read_npy("spec_transform_fish_c_order.npy")?;
-    let encoder = FireflyArchitecture::load(vb)?;
+    let encoder = FireflyEncoder::load(vb, &FireflyConfig::fish_speech_1_2())?;
     // Temporarily skipping our own preprocessing code and hard-coding to isolate numerical accuracy elsewhere
     let result = encoder.encode(&override_mel)?.squeeze(0)?;
     println!("Generated indices of shape {:?}", result.shape());


### PR DESCRIPTION
This PR adds:
- GroupedResidualFSQ dequantize implementation: matches upstream to ~1e-3

This PR fixes:
- Config for VQGAN centralized
- Encoder and decoder split to avoid loading unnecessary weights

```
Maximum absolute difference: 0.0010838508605957031
Mean absolute difference: 4.766542406287044e-05
Number of elements exceeding tolerance: 2 out of 113664
Percentage of differing elements: 0.00%
```