### PR TITLE
Add HiFiGAN decoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ checkpoints
 *.npy
 # For debugging purposes; remove before production!
 !spec_transform_fish_c_order.npy
+fake.wav

--- a/fish_speech_core/lib/audio/mod.rs
+++ b/fish_speech_core/lib/audio/mod.rs
@@ -1,6 +1,7 @@
 pub mod functional;
 pub mod pcm_decode;
 pub mod spectrogram;
+pub mod wav;
 
 use anyhow::{bail, Result};
 use byteorder::{ByteOrder, LittleEndian};

--- a/fish_speech_core/lib/audio/wav.rs
+++ b/fish_speech_core/lib/audio/wav.rs
@@ -1,0 +1,58 @@
+// Copied wholesale and vendored from candle_examples::wav.
+// Thanks again, Laurent Mazare
+use std::io::prelude::*;
+
+pub trait Sample {
+    fn to_i16(&self) -> i16;
+}
+
+impl Sample for f32 {
+    fn to_i16(&self) -> i16 {
+        (self.clamp(-1.0, 1.0) * 32767.0) as i16
+    }
+}
+
+impl Sample for f64 {
+    fn to_i16(&self) -> i16 {
+        (self.clamp(-1.0, 1.0) * 32767.0) as i16
+    }
+}
+
+impl Sample for i16 {
+    fn to_i16(&self) -> i16 {
+        *self
+    }
+}
+
+pub fn write_pcm_as_wav<W: Write, S: Sample>(
+    w: &mut W,
+    samples: &[S],
+    sample_rate: u32,
+) -> std::io::Result<()> {
+    let len = 12u32; // header
+    let len = len + 24u32; // fmt
+    let len = len + samples.len() as u32 * 2 + 8; // data
+    let n_channels = 1u16;
+    let bytes_per_second = sample_rate * 2 * n_channels as u32;
+    w.write_all(b"RIFF")?;
+    w.write_all(&(len - 8).to_le_bytes())?; // total length minus 8 bytes
+    w.write_all(b"WAVE")?;
+
+    // Format block
+    w.write_all(b"fmt ")?;
+    w.write_all(&16u32.to_le_bytes())?; // block len minus 8 bytes
+    w.write_all(&1u16.to_le_bytes())?; // PCM
+    w.write_all(&n_channels.to_le_bytes())?; // one channel
+    w.write_all(&sample_rate.to_le_bytes())?;
+    w.write_all(&bytes_per_second.to_le_bytes())?;
+    w.write_all(&2u16.to_le_bytes())?; // 2 bytes of data per sample
+    w.write_all(&16u16.to_le_bytes())?; // bits per sample
+
+    // Data block
+    w.write_all(b"data")?;
+    w.write_all(&(samples.len() as u32 * 2).to_le_bytes())?;
+    for sample in samples.iter() {
+        w.write_all(&sample.to_i16().to_le_bytes())?
+    }
+    Ok(())
+}

--- a/fish_speech_core/lib/models/vqgan/decoder.rs
+++ b/fish_speech_core/lib/models/vqgan/decoder.rs
@@ -1,5 +1,5 @@
 use candle_core::{Device, Result, Tensor, D};
-use candle_nn::VarBuilder;
+use candle_nn::{Module, VarBuilder};
 
 use super::hifi_gan::HiFiGAN;
 use super::quantizer::DownsampleFiniteScalarQuantizer;
@@ -52,16 +52,19 @@ impl FireflyDecoder {
             Some((indices.dim(2)? * factor * self.cfg.spec_transform.hop_length) as u32),
             indices.device(),
         )?;
-        let audio_masks_float_conv = audio_masks.unsqueeze(1)?;
 
         let z = self.quantizer.decode(indices)?;
         let mel_masks_float_conv = mel_masks.unsqueeze(1)?.to_dtype(z.dtype())?;
+        let audio_masks_float_conv = audio_masks.unsqueeze(1)?.to_dtype(z.dtype())?;
         println!(
             "z: {:?}, mel masks: {:?}",
             z.shape(),
             mel_masks_float_conv.shape()
         );
 
-        z.broadcast_mul(&mel_masks_float_conv)
+        let z = z.broadcast_mul(&mel_masks_float_conv)?;
+        self.head
+            .forward(&z)?
+            .broadcast_mul(&audio_masks_float_conv)
     }
 }

--- a/fish_speech_core/lib/models/vqgan/decoder.rs
+++ b/fish_speech_core/lib/models/vqgan/decoder.rs
@@ -56,11 +56,6 @@ impl FireflyDecoder {
         let z = self.quantizer.decode(indices)?;
         let mel_masks_float_conv = mel_masks.unsqueeze(1)?.to_dtype(z.dtype())?;
         let audio_masks_float_conv = audio_masks.unsqueeze(1)?.to_dtype(z.dtype())?;
-        println!(
-            "z: {:?}, mel masks: {:?}",
-            z.shape(),
-            mel_masks_float_conv.shape()
-        );
 
         let z = z.broadcast_mul(&mel_masks_float_conv)?;
         self.head

--- a/fish_speech_core/lib/models/vqgan/grouped_residual_fsq.rs
+++ b/fish_speech_core/lib/models/vqgan/grouped_residual_fsq.rs
@@ -171,7 +171,6 @@ impl GroupedResidualFSQ {
     }
 
     pub fn get_output_from_indices(&self, indices: &Tensor) -> Result<Tensor> {
-        println!("Index shape before chunk: {:?}", indices.shape());
         let indices = indices.chunk(self.groups, 0)?;
 
         let out: Result<Vec<Tensor>> = self

--- a/fish_speech_core/lib/models/vqgan/hifi_gan.rs
+++ b/fish_speech_core/lib/models/vqgan/hifi_gan.rs
@@ -1,11 +1,213 @@
 use super::utils::config::HiFiGANConfig;
-use candle_core::Result;
-use candle_nn::{Conv1d, VarBuilder};
+use candle_core::{Result, Tensor};
+use candle_nn::{Conv1d, Conv1dConfig, ConvTranspose1d, ConvTranspose1dConfig, Module, VarBuilder};
 
-pub struct HiFiGAN {}
+fn get_padding(kernel_size: usize, dilation: Option<usize>) -> usize {
+    let dilation = dilation.unwrap_or(1);
+    (kernel_size * dilation - dilation) / 2
+}
+
+struct ResBlock1 {
+    convs1: Vec<Conv1d>,
+    convs2: Vec<Conv1d>,
+}
+
+impl ResBlock1 {
+    pub fn load(
+        vb: &VarBuilder,
+        channels: usize,
+        kernel_size: usize,
+        dilation: &Vec<usize>,
+    ) -> Result<Self> {
+        let mut convs1: Vec<Conv1d> = vec![];
+        let mut convs2: Vec<Conv1d> = vec![];
+
+        for (i, d) in dilation.iter().enumerate() {
+            let conv = Conv1d::new(
+                vb.get(
+                    (channels, channels, kernel_size),
+                    &format!("convs1.{}.weight", i),
+                )?,
+                Some(vb.get(channels, &format!("convs1.{}.bias", i))?),
+                Conv1dConfig {
+                    stride: 1,
+                    dilation: *d,
+                    padding: get_padding(kernel_size, Some(*d)),
+                    groups: 1,
+                },
+            );
+            convs1.push(conv)
+        }
+
+        for i in 0..dilation.len() {
+            let conv = Conv1d::new(
+                vb.get(
+                    (channels, channels, kernel_size),
+                    &format!("convs2.{}.weight", i),
+                )?,
+                Some(vb.get(channels, &format!("convs2.{}.bias", i))?),
+                Conv1dConfig {
+                    stride: 1,
+                    dilation: 1,
+                    padding: get_padding(kernel_size, Some(1)),
+                    groups: 1,
+                },
+            );
+            convs2.push(conv);
+        }
+
+        Ok(Self { convs1, convs2 })
+    }
+}
+
+impl Module for ResBlock1 {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let mut x = xs.clone();
+        for (c1, c2) in self.convs1.iter().zip(self.convs2.iter()) {
+            let xt = x.silu()?;
+            let xt = c1.forward(&xt)?.silu()?;
+            let xt = c2.forward(&xt)?;
+            x = x.add(&xt)?;
+        }
+        Ok(x)
+    }
+}
+
+struct ParallelBlock {
+    blocks: Vec<ResBlock1>,
+}
+
+impl ParallelBlock {
+    pub fn load(
+        vb: &VarBuilder,
+        channels: usize,
+        kernel_sizes: &Vec<usize>,
+        dilation_sizes: &Vec<Vec<usize>>,
+    ) -> Result<Self> {
+        let blocks: Result<Vec<ResBlock1>> = kernel_sizes
+            .iter()
+            .zip(dilation_sizes.iter())
+            .enumerate()
+            .map(|(i, (k, d))| ResBlock1::load(&vb.pp(format!("blocks.{}", i)), channels, *k, d))
+            .collect();
+
+        Ok(Self { blocks: blocks? })
+    }
+}
+
+impl Module for ParallelBlock {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let results: Result<Vec<Tensor>> = self.blocks.iter().map(|b| b.forward(xs)).collect();
+        Tensor::stack(&results?, 0)?.mean(0)
+    }
+}
+
+pub struct HiFiGAN {
+    conv_pre: Conv1d,
+    num_upsamples: usize,
+    num_kernels: usize,
+    ups: Vec<ConvTranspose1d>,
+    resblocks: Vec<ParallelBlock>,
+    conv_post: Conv1d,
+}
 
 impl HiFiGAN {
     pub fn load(vb: VarBuilder, cfg: &HiFiGANConfig) -> Result<Self> {
-        Ok(Self {})
+        let conv_pre = Conv1d::new(
+            vb.get(
+                (
+                    cfg.num_mels,
+                    cfg.upsample_initial_channel,
+                    cfg.pre_conv_kernel_size,
+                ),
+                "conv_pre.weight",
+            )?,
+            Some(vb.get(cfg.upsample_initial_channel, "conv_pre.bias")?),
+            Conv1dConfig {
+                stride: 1,
+                padding: get_padding(cfg.pre_conv_kernel_size, None),
+                dilation: 1,
+                groups: 1,
+            },
+        );
+        let num_upsamples = cfg.upsample_rates.len();
+        let num_kernels = cfg.resblock_kernel_sizes.len();
+
+        let mut ups: Vec<ConvTranspose1d> = vec![];
+
+        for (i, (u, k)) in cfg
+            .upsample_rates
+            .iter()
+            .zip(cfg.upsample_kernel_sizes.iter())
+            .enumerate()
+        {
+            // Ignoring noise_convs for inference
+            ups.push(ConvTranspose1d::new(
+                vb.get(
+                    (
+                        cfg.upsample_initial_channel / 2_usize.pow(i as u32),
+                        cfg.upsample_initial_channel / 2_usize.pow(i as u32 + 1),
+                        *k,
+                    ),
+                    &format!("ups.{}.weight", i),
+                )?,
+                Some(vb.get(
+                    cfg.upsample_initial_channel / 2_usize.pow(i as u32 + 1),
+                    &format!("ups.{}.bias", i),
+                )?),
+                ConvTranspose1dConfig {
+                    stride: *u,
+                    padding: (k - u) / 2,
+                    output_padding: 0,
+                    groups: 1,
+                    dilation: 1,
+                },
+            ));
+        }
+
+        let resblocks: Result<Vec<ParallelBlock>> = (0..ups.len())
+            .map(|i| {
+                let ch = cfg.upsample_initial_channel / 2_usize.pow(i as u32 + 1);
+                ParallelBlock::load(
+                    &vb.pp(format!("resblocks.{}", i)),
+                    ch,
+                    &cfg.resblock_kernel_sizes,
+                    &cfg.resblock_dilation_sizes,
+                )
+            })
+            .collect();
+
+        let ch_final = cfg.upsample_initial_channel / 2_usize.pow(ups.len() as u32);
+        let conv_post = Conv1d::new(
+            vb.get((1, ch_final, cfg.post_conv_kernel_size), "conv_post.weight")?,
+            Some(vb.get(1, "conv_post.bias")?),
+            Conv1dConfig {
+                stride: 1,
+                padding: get_padding(cfg.post_conv_kernel_size, None),
+                groups: 1,
+                dilation: 1,
+            },
+        );
+
+        Ok(Self {
+            conv_pre,
+            num_upsamples,
+            num_kernels,
+            ups,
+            resblocks: resblocks?,
+            conv_post,
+        })
+    }
+}
+
+impl Module for HiFiGAN {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let mut xs = self.conv_pre.forward(xs)?;
+        for (u, r) in self.ups.iter().zip(self.resblocks.iter()) {
+            let x = u.forward(&xs.silu()?)?;
+            xs = r.forward(&x)?;
+        }
+        let x = self.conv_post.forward(&xs.silu()?)?;
+        x.tanh()
     }
 }

--- a/fish_speech_core/lib/models/vqgan/quantizer.rs
+++ b/fish_speech_core/lib/models/vqgan/quantizer.rs
@@ -96,7 +96,6 @@ impl DownsampleFiniteScalarQuantizer {
 
     pub fn encode(&self, z: &Tensor) -> Result<Tensor> {
         let z = self.downsample.forward(z)?;
-        println!("Index shape before encoding: {:?}", z.shape());
 
         // Transpose z (equivalent to .mT in Python)
         let z_t = z.transpose(1, 2)?;

--- a/fish_speech_core/lib/models/vqgan/quantizer.rs
+++ b/fish_speech_core/lib/models/vqgan/quantizer.rs
@@ -129,7 +129,6 @@ impl DownsampleFiniteScalarQuantizer {
             gr / self.residual_fsq.groups,
         ))?;
         let z_q = self.residual_fsq.get_output_from_indices(&indices)?;
-        println!("z_q shape: {:?}", z_q.shape());
         self.upsample(&z_q.transpose(1, 2)?)
     }
 }

--- a/fish_speech_core/src/bin/vocoder.rs
+++ b/fish_speech_core/src/bin/vocoder.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use candle_core::{DType, Device, Tensor, D};
 use candle_nn::VarBuilder;
+use fish_speech_core::audio::wav::write_pcm_as_wav;
 use fish_speech_core::models::vqgan::decoder::FireflyDecoder;
 use fish_speech_core::models::vqgan::utils::config::FireflyConfig;
 use std::time::{Duration, Instant};
@@ -19,18 +20,26 @@ fn main() -> Result<()> {
 
     // TODO: Support Fish 1.4
     println!("Loading model");
-    let model = FireflyDecoder::load(&vb, &FireflyConfig::fish_speech_1_2())?;
+    let config = FireflyConfig::fish_speech_1_2();
+    let model = FireflyDecoder::load(&vb, &config)?;
     println!("Model loaded");
+
     let feature_lengths = Tensor::from_slice(&[input.dim(D::Minus1)? as u32], 1, &device)?;
     let start_decode = Instant::now();
     let fake_audios = model.decode(&input.unsqueeze(0)?, &feature_lengths)?;
+
     let dt = start_decode.elapsed();
+    println!("Generated: {:?}", fake_audios.shape());
     println!(
         "Time to decode: {:.2}s (RTF: {:.3})",
         dt.as_secs_f64(),
         (fake_audios.dim(D::Minus1)? as f64 / 44100 as f64) / dt.as_secs_f64()
     );
     // fake_audios.write_npy("vocoder_decode_rust.npy")?;
+    let pcm = fake_audios.squeeze(0)?.squeeze(0)?.to_vec1::<f32>()?;
+    // TODO: parameterize this
+    let mut output = std::fs::File::create("./fake.wav")?;
+    write_pcm_as_wav(&mut output, &pcm, config.spec_transform.sample_rate as u32)?;
 
     Ok(())
 }

--- a/fish_speech_core/src/bin/vocoder.rs
+++ b/fish_speech_core/src/bin/vocoder.rs
@@ -3,6 +3,7 @@ use candle_core::{DType, Device, Tensor, D};
 use candle_nn::VarBuilder;
 use fish_speech_core::models::vqgan::decoder::FireflyDecoder;
 use fish_speech_core::models::vqgan::utils::config::FireflyConfig;
+use std::time::{Duration, Instant};
 
 fn main() -> Result<()> {
     let input = Tensor::read_npy("out.npy")?;
@@ -11,7 +12,7 @@ fn main() -> Result<()> {
     // TODO: Support hardware acceleration;
     let device = Device::Cpu;
     let vb = VarBuilder::from_pth(
-        "checkpoints/fish-speech-1.2-sft/firefly-gan-vq-fsq-4x1024-42hz-generator.pth",
+        "checkpoints/fish-speech-1.2-sft/firefly-gan-vq-fsq-4x1024-42hz-generator-merged.pth",
         dtype,
         &device,
     )?;
@@ -21,9 +22,15 @@ fn main() -> Result<()> {
     let model = FireflyDecoder::load(&vb, &FireflyConfig::fish_speech_1_2())?;
     println!("Model loaded");
     let feature_lengths = Tensor::from_slice(&[input.dim(D::Minus1)? as u32], 1, &device)?;
+    let start_decode = Instant::now();
     let fake_audios = model.decode(&input.unsqueeze(0)?, &feature_lengths)?;
-    // println!("Fake audios: {:?}", fake_audios.is_ok());
-    fake_audios.write_npy("quantizer_decode_rust.npy")?;
+    let dt = start_decode.elapsed();
+    println!(
+        "Time to decode: {:.2}s (RTF: {:.3})",
+        dt.as_secs_f64(),
+        (fake_audios.dim(D::Minus1)? as f64 / 44100 as f64) / dt.as_secs_f64()
+    );
+    // fake_audios.write_npy("vocoder_decode_rust.npy")?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds:
- Numerically accurate HiFiGAN forward pass for CPU

```
Array 1 Information:
Shape: (1, 1, 113664)
Data type: float32
Order: Fortran-contiguous
Min value: -0.3400823473930359
Max value: 0.36171290278434753
Mean value: -6.575903535122052e-05

Array 2 Information:
Shape: (1, 1, 113664)
Data type: float32
Order: Fortran-contiguous
Min value: -0.3401753306388855
Max value: 0.3616633713245392
Mean value: -6.943198968656361e-05

Comparison results (tolerance: 0.001):
Arrays are close: False
Maximum absolute difference: 0.001000910997390747
Mean absolute difference: 4.363413972896524e-05
Number of elements exceeding tolerance: 1 out of 113664
Percentage of differing elements: 0.00%

Difference locations summary:
Dimension 0: All values, Dimension 1: All values, Dimension 2: [36081]
```

Next steps:
- Metal / CUDA support
- Configurable CLI args to match upstream
- Fish 1.4 support
- Working documentation
- Canonical HF link to .safetensors (weight-normalized weights had to be merged)