### PR TITLE
Optimize slow token sampling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 members = ["fish_speech_core", "fish_speech_python"]
 resolver = "2"
+
+[profile.release-with-debug]
+inherits = "release"
+debug = true

--- a/fish_speech_core/lib/models/text2semantic/utils/encode.rs
+++ b/fish_speech_core/lib/models/text2semantic/utils/encode.rs
@@ -52,8 +52,8 @@ pub fn encode_tokens(
     )?;
 
     // Fill in the speaker line
-    let s0_token_id = tokenizer.encode("<|semantic|>", false).unwrap().get_ids()[0];
-    let end_token_id = tokenizer.encode("<|im_end|>", false).unwrap().get_ids()[0];
+    let s0_token_id = tokenizer.token_to_id("<|semantic|>").unwrap_or(5);
+    let end_token_id = tokenizer.token_to_id("<|im_end|>").unwrap_or(4);
     let mut main_token_ids = vec![s0_token_id; data.dim(D::Minus1)? - 1];
     main_token_ids.push(end_token_id);
     let main_token_ids = Tensor::from_vec(main_token_ids, (1, data.dim(1)?), device)?;

--- a/fish_speech_core/lib/models/vqgan/decoder.rs
+++ b/fish_speech_core/lib/models/vqgan/decoder.rs
@@ -62,7 +62,6 @@ impl FireflyDecoder {
             .head
             .forward(&z)?
             .broadcast_mul(&audio_masks_float_conv)?;
-        out.write_npy("fish_1_4_decode_rs.npy")?;
         Ok(out)
     }
 }

--- a/fish_speech_core/src/bin/llama_generate.rs
+++ b/fish_speech_core/src/bin/llama_generate.rs
@@ -55,8 +55,14 @@ fn decode_one_token_ar(
     let slow_logits = logits.flatten_all()?;
     let repeat_window_size = 16;
 
-    let mut pad_prob = slow_logits.i(pad_id as usize)?.to_scalar::<f32>()?;
-    let eos_prob = slow_logits.i(im_end_id as usize)?.to_scalar::<f32>()?;
+    let mut pad_prob = slow_logits
+        .i(pad_id as usize)?
+        .to_dtype(DType::F32)?
+        .to_scalar::<f32>()?;
+    let eos_prob = slow_logits
+        .i(im_end_id as usize)?
+        .to_dtype(DType::F32)?
+        .to_scalar::<f32>()?;
 
     if previous_tokens.is_some() {
         pad_prob /= sampling_args.repetition_penalty;

--- a/fish_speech_core/src/bin/vocoder.rs
+++ b/fish_speech_core/src/bin/vocoder.rs
@@ -81,7 +81,9 @@ fn main() -> Result<()> {
     let feature_lengths = Tensor::from_slice(&[input.dim(D::Minus1)? as u32], 1, &device)?;
 
     let start_decode = Instant::now();
-    let fake_audios = model.decode(&input.unsqueeze(0)?, &feature_lengths)?;
+    let fake_audios = model
+        .decode(&input.unsqueeze(0)?, &feature_lengths)?
+        .to_dtype(DType::F32)?;
 
     let dt = start_decode.elapsed();
     println!(


### PR DESCRIPTION
This PR adds:
- Moved semantic ("slow") token to greedy sampling with rep pen, per the original maintainers: https://github.com/fishaudio/fish-speech/issues/567#issuecomment-2360029630.
- Optimized slow sampling by only considering the argmax of `<|semantic|>` and `<|im_end|>` tokens, as they're the only legal values

This PR fixes:
- Decoder output now works with native BF16 weights

On an RTX 4090, sampling is up from 101 tokens/sec to 133 tokens/sec.

Sampling time before changes:
<img width="1057" alt="Pasted image 20241001235937" src="https://github.com/user-attachments/assets/01d572c7-dabe-463c-87f3-e800c309c6af">

Sampling time after:
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/afe7818e-7ed0-4dc9-9da5-2bf4393f30b4">

Next step: Switching transformer blocks to fused kernels, investigating copy2d usage