### PR TITLE
Optimize embedding layers

### DIFF
--- a/fish_speech_core/src/bin/llama_generate.rs
+++ b/fish_speech_core/src/bin/llama_generate.rs
@@ -78,7 +78,7 @@ fn decode_one_token_ar(
     let slow_logits = logits.flatten_all()?;
     let repeat_window_size = 16;
 
-    let mut pad_prob = slow_logits
+    let pad_prob = slow_logits
         .i(pad_id as usize)?
         .to_dtype(DType::F32)?
         .to_scalar::<f32>()?;

--- a/fish_speech_core/src/bin/llama_generate.rs
+++ b/fish_speech_core/src/bin/llama_generate.rs
@@ -235,7 +235,7 @@ fn generate_long(
         &sampling_args,
     )?;
     let res = res.broadcast_sub(&Tensor::ones_like(&res)?)?;
-    res.write_npy(args.out_path.canonicalize()?)?;
+    res.write_npy(&args.out_path)?;
 
     Ok(())
 }

--- a/fish_speech_core/src/bin/llama_generate.rs
+++ b/fish_speech_core/src/bin/llama_generate.rs
@@ -113,9 +113,10 @@ fn generate(
 ) -> Result<Tensor> {
     let sampling = match sampling_args.temp {
         0.0 => Sampling::ArgMax,
-        temp => Sampling::TopP {
+        temp => Sampling::TopKThenTopP {
             temperature: temp,
             p: sampling_args.top_p,
+            k: sampling_args.top_k,
         },
     };
     let mut fast_logits_processor = LogitsProcessor::from_sampling(42, sampling);
@@ -193,6 +194,7 @@ fn generate_long(
     let sampling_args = SamplingArgs {
         temp: args.temp,
         top_p: args.top_p,
+        top_k: args.top_k,
         repetition_penalty: args.repetition_penalty,
     };
 
@@ -243,6 +245,7 @@ fn generate_long(
 struct SamplingArgs {
     pub temp: f64,
     pub top_p: f64,
+    pub top_k: usize,
     pub repetition_penalty: f32,
 }
 
@@ -282,6 +285,10 @@ struct Args {
     /// Top-p sampling parameter
     #[arg(long, default_value_t = 0.7)]
     top_p: f64,
+
+    /// Top-k sampling parameter. Set high by default
+    #[arg(long, default_value_t = 256)]
+    top_k: usize,
 
     /// Penalty for repetition
     #[arg(long, default_value_t = 1.2)]


### PR DESCRIPTION
This PR fixes:
- Initial WTE embedding step now parallelized across non-semantic codebooks instead of serial. Results are numerically equivalent. This shaves off about 300µs per token: i.e. most of this section:
<img width="1214" alt="image" src="https://github.com/user-attachments/assets/b48ee407-5bf6-4a74-bb24-5432ab8ed297">

Is now somewhere around here (ignore exact numbers):
<img width="188" alt="image" src="https://github.com/user-attachments/assets/9148ed59-9d10-473e-8b18-2dc38ded64b2">

- Top-k option added for fast codebooks to increase performance. Set to a rather generous 256 by default to avoid impacting generation quality. Shaves off another few hundred microseconds. To turn this off, set `--top-k=1024`.
- Saving `out.npy` for first time now doesn't error
- EOS token now at temp=1 after I noticed clipping was too aggressive. Raise an issue if anyone wants this to be configurable

Totally unscientific performance speedup on RTX 4090 release binary:
BEFORE:
```
Loaded prompt with shape [9, 166]
166 prompt processing timesteps (1630.66 tokens/s)
\ Tokens: 127 [00:00:00] 131.9143/s iterations/s                                                                                                                                                                                          128 tokens generated (133.92 tokens/s, RTF: 3.109)
```

AFTER:
```
166 prompt processing timesteps (1656.16 tokens/s)
\ Tokens: 129 [00:00:00] 142.265/s iterations/s                                                                                                                                                                                           131 tokens generated (144.58 tokens/s, 6.917ms / token, RTF: 3.357)
```

Next steps: Kernel fusion on transformer layers