### PR TITLE
Add CUDA flash attention kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,9 @@ name = "anyhow"
 version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arbitrary"
@@ -240,6 +243,18 @@ dependencies = [
  "thiserror",
  "yoke",
  "zip",
+]
+
+[[package]]
+name = "candle-flash-attn"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bc10eecc80be2f7916525eb6aa20aa580c1a07ffacfef7183cfea964b92c6f"
+dependencies = [
+ "anyhow",
+ "bindgen_cuda",
+ "candle-core",
+ "half",
 ]
 
 [[package]]
@@ -657,6 +672,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "candle-core",
+ "candle-flash-attn",
  "candle-nn",
  "candle-transformers",
  "clap",

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ For additional speed, compile with [Flash Attention](https://arxiv.org/abs/2205.
 > Also, of October 2024 the bottleneck is actually elsewhere (in inefficient memory copies and kernel dispatch), so on already fast hardware (like an RTX 4090) this currently has less of an impact. 
 
 ```bash
-# Cache build directory
-# Leave your computer, go touch grass, have a cup of tea, etc.
+# Cache the Flash Attention build
+# Leave your computer, have a cup of tea, go touch grass, etc.
+mkdir ~/.candle
 CANDLE_FLASH_ATTN_BUILD_DIR=$HOME/.candle cargo build --release --features flash-attn --bin llama_generate
 
 # Then run with flash-attn flag

--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ For Fish 1.2, you'll have to specify version and checkpoint explicitly:
 cargo run --release --features metal --bin llama_generate -- --text "That is not dead which can eternal lie, and with strange aeons even death may die." --fish-version 1.2 --checkpoint ./checkpoints/fish-speech-1.2-sft
 ```
 
+For additional speed, compile with [Flash Attention](https://arxiv.org/abs/2205.14135) support. 
+
+> [!WARNING]
+> 
+> The candle-flash-attention dependency [can take more than 10 minutes to compile](https://github.com/huggingface/candle/issues/2275) even on a good CPU, and can require more than 16 GB of memory! You have been warned. 
+> 
+> Also, of October 2024 the bottleneck is actually elsewhere (in inefficient memory copies and kernel dispatch), so on already fast hardware (like an RTX 4090) this currently has less of an impact. 
+
+```bash
+# Cache build directory
+# Leave your computer, go touch grass, have a cup of tea, etc.
+CANDLE_FLASH_ATTN_BUILD_DIR=$HOME/.candle cargo build --release --features flash-attn --bin llama_generate
+
+# Then run with flash-attn flag
+cargo run --release --features flash-attn --bin llama_generate -- \
+  --text "That is not dead which can eternal lie, and with strange aeons even death may die." \
+  --prompt-text "When I heard the release demo, I was shocked, angered, and in disbelief that Mr. Altman would pursue a voice that sounded so eerily similar to mine that my closest friends and news outlets could not tell the difference." \
+  --prompt-tokens fake.npy
+```
+
+
 ### Decode tokens to WAV
 
 For Fish 1.4 (default):

--- a/fish_speech_core/Cargo.toml
+++ b/fish_speech_core/Cargo.toml
@@ -10,11 +10,14 @@ path = "lib/lib.rs"
 [features]
 cuda = ["candle-core/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
 metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal"]
+flash-attn = ["cuda", "dep:candle-flash-attn"]
+
 
 [dependencies]
 anyhow = "1.0.86"
 byteorder = "1.5.0"
 candle-core = "0.7.1"
+candle-flash-attn = { version = "0.7.1", optional = true }
 candle-nn = "0.7.1"
 candle-transformers = "0.7.1"
 clap = { version = "4.5.16", features = ["derive"] }


### PR DESCRIPTION
This PR adds:
- CUDA flash attention kernels from [candle-flash-attn](https://github.com/huggingface/candle/tree/main/candle-flash-attn)

Right now this doesn't really do much for speed, because the bottlenecks are still:
- repeat_interleave for the KV cache
- (Surprisingly enough) Residual add + norm: It's not fused so the dispatching overhead dwarfs compute, and `broadcast_add` is also surprisingly slow 

Totally unscientifically, times are improved from 6200µs/token to 5781µs/token on a 4090.

Next priority: Kernel fusion! God help me, it's time to write a CustomOp and learn CUDA...

<img width="887" alt="image" src="https://github.com/user-attachments/assets/e370c199-d7fc-47d2-827f-e09d0ebcf818">

