### PR TITLE
Reduce penalty from vocab size increase

### DIFF
--- a/fish_speech_core/lib/models/text2semantic/utils/generate.rs
+++ b/fish_speech_core/lib/models/text2semantic/utils/generate.rs
@@ -152,8 +152,9 @@ pub fn generate(
     let dt = start_decode.elapsed();
     let out_len = previous_tokens.dim(1)? as f64;
     println!(
-        "{} tokens generated ({:.2} tokens/s, {:.3}ms / token, RTF: {:.3})",
+        "{} tokens generated in {:.3}s ({:.2} tokens/s, {:.3}ms / token, RTF: {:.3})",
         out_len,
+        dt.as_secs_f64(),
         out_len / dt.as_secs_f64(),
         (dt.as_secs_f64() * 1e3) / (out_len - 1f64),
         (out_len / 21.535) / dt.as_secs_f64()

--- a/fish_speech_core/lib/models/text2semantic/utils/generate.rs
+++ b/fish_speech_core/lib/models/text2semantic/utils/generate.rs
@@ -31,8 +31,10 @@ fn decode_one_token_ar(
         // Ah the halcyon days where we're not forced to do a giant softmax to double up the first semantic codes
         legacy_softmax_sample(pad_prob, eos_prob, pad_id, im_end_id)
     } else {
-        // TODO DO NOT MERGE: add the split again. I can't be bothered
-        fast_logits_processor.sample(&slow_logits)?
+        // Assumes im_end_id will always come after start. Since it's just 1.5 this is fine
+        let special_token_range = slow_logits.i(im_end_id as usize..)?.contiguous()?;
+        let shifted_token = fast_logits_processor.sample(&special_token_range)?;
+        shifted_token + im_end_id
     };
     let mut codebooks = vec![semantic_token];
     model.clear_fast_layer_caches();

--- a/fish_speech_core/lib/models/text2semantic/utils/text.rs
+++ b/fish_speech_core/lib/models/text2semantic/utils/text.rs
@@ -151,8 +151,6 @@ fn clean_text(text: &str) -> String {
 
 fn split_into_chunks(text: &str) -> Vec<TextChunk> {
     let mut chunks = Vec::new();
-    let mut current_chunk = String::new();
-    let mut current_bytes = 0;
 
     // First pass: collect sentences and their sizes
     let sentences: Vec<&str> = text.split_inclusive(&['.', '!', '?'][..]).collect();
@@ -160,23 +158,23 @@ fn split_into_chunks(text: &str) -> Vec<TextChunk> {
         return chunks;
     }
 
-    let mut flush_chunk = |chunk: String, force_pause: bool| -> Option<String> {
-        if chunk.is_empty() {
-            return None;
-        }
+    // let flush_chunk = |chunk: String, force_pause: bool| -> Option<String> {
+    //     if chunk.is_empty() {
+    //         return None;
+    //     }
 
-        // Only flush if we're over MIN_CHUNK_BYTES or it's the very last bit
-        if chunk.len() >= MIN_CHUNK_BYTES || force_pause {
-            chunks.push(TextChunk {
-                text: chunk,
-                should_pause_after: force_pause,
-            });
-            None
-        } else {
-            // Return the chunk to be combined with the next one
-            Some(chunk)
-        }
-    };
+    //     // Only flush if we're over MIN_CHUNK_BYTES or it's the very last bit
+    //     if chunk.len() >= MIN_CHUNK_BYTES || force_pause {
+    //         chunks.push(TextChunk {
+    //             text: chunk,
+    //             should_pause_after: force_pause,
+    //         });
+    //         None
+    //     } else {
+    //         // Return the chunk to be combined with the next one
+    //         Some(chunk)
+    //     }
+    // };
 
     let mut pending_small_chunk: Option<String> = None;
 

--- a/fish_speech_core/src/bin/llama_generate.rs
+++ b/fish_speech_core/src/bin/llama_generate.rs
@@ -1,5 +1,5 @@
 use anyhow::Error;
-use candle_core::{DType, Device, IndexOp, Result, Tensor, D};
+use candle_core::{DType, Device, Result, Tensor, D};
 use candle_nn::VarBuilder;
 use clap::Parser;
 use fish_speech_core::models::text2semantic::utils::{


### PR DESCRIPTION
Fixes #22 

This PR re-adds constrained sampling for semantic ID tokens on slow transformer, sampling the ~1030 vocab of special tokens instead of the full 100k (since only VQ tokens and EOS are generated at runtime).


On a 4090 this results in a ~800µs savings per token, a 20% speedup for autoregressive generation, with identical output. The 1.4 -> 1.5 change still added 140µs/token for the logit layer due to the vocab change, but that can't be fixed without retraining.


Before:
<img width="1897" alt="image" src="https://github.com/user-attachments/assets/b64c3d78-0ff2-4622-b82a-044d471c64eb">

After:
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/267e8116-bacd-4a1f-b99a-7ada7e58bf8f">

