### PR TITLE
Make chunking more aggressive for earlier chunks

### DIFF
--- a/fish_speech_core/lib/models/text2semantic/utils/generate.rs
+++ b/fish_speech_core/lib/models/text2semantic/utils/generate.rs
@@ -78,6 +78,8 @@ pub fn generate_blocking_with_hidden(
             k: sampling_args.top_k,
         },
     };
+    // TODO: make this configurable. but if you need determinism, you'd probably just set temp=0 anyhow
+    // let mut fast_logits_processor = LogitsProcessor::from_sampling(rand::random::<u64>(), sampling);
     let mut fast_logits_processor = LogitsProcessor::from_sampling(42, sampling);
     let maybe_fast_rep_pens: Result<Vec<RepPenProcessor>> = (0..model.cfg.num_codebooks)
         .map(|_| {

--- a/fish_speech_core/lib/models/text2semantic/utils/generate.rs
+++ b/fish_speech_core/lib/models/text2semantic/utils/generate.rs
@@ -78,9 +78,7 @@ pub fn generate_blocking_with_hidden(
             k: sampling_args.top_k,
         },
     };
-    // TODO: make this configurable. but if you need determinism, you'd probably just set temp=0 anyhow
-    // let mut fast_logits_processor = LogitsProcessor::from_sampling(rand::random::<u64>(), sampling);
-    let mut fast_logits_processor = LogitsProcessor::from_sampling(42, sampling);
+    let mut fast_logits_processor = LogitsProcessor::from_sampling(rand::random::<u64>(), sampling);
     let maybe_fast_rep_pens: Result<Vec<RepPenProcessor>> = (0..model.cfg.num_codebooks)
         .map(|_| {
             RepPenProcessor::new(

--- a/server/lib/handlers/speech.rs
+++ b/server/lib/handlers/speech.rs
@@ -24,11 +24,14 @@ pub async fn server_lm_generate_blocking(
     n_conditioning_tokens: usize,
     collect_hidden_states: bool,
 ) -> Result<(Tensor, Option<Tensor>), anyhow::Error> {
+    // Arbitrary number
+    let max_tokens: usize = 768;
+
     let mut model = state.semantic_model.lock().await;
     let (tokens, hidden_states) = generate_blocking_with_hidden(
         &mut model,
         &encoded_input,
-        1024,
+        max_tokens,
         state.tokenizer.token_to_id("<|im_end|>").unwrap_or(4),
         state.tokenizer.token_to_id("<|semantic|>").unwrap_or(5),
         sampling_args,
@@ -36,8 +39,32 @@ pub async fn server_lm_generate_blocking(
     )
     .context("Failed to generate tokens")?;
 
+    let mut tokens = tokens;
+    let mut hidden_states = hidden_states;
     // It's the caller's responsibility to do final clear
     model.clear_slow_caches_until(n_conditioning_tokens)?;
+    if tokens.dim(D::Minus1)? == max_tokens {
+        println!("Failed generation suspected. Rerolling once");
+        let (new_tokens, new_hidden_states) = generate_blocking_with_hidden(
+            &mut model,
+            &encoded_input,
+            1024,
+            state.tokenizer.token_to_id("<|im_end|>").unwrap_or(4),
+            state.tokenizer.token_to_id("<|semantic|>").unwrap_or(5),
+            sampling_args,
+            collect_hidden_states,
+        )
+        .context("Failed to generate tokens")?;
+        if new_tokens.dim(D::Minus1)? != max_tokens {
+            tokens = new_tokens;
+            hidden_states = new_hidden_states;
+        } else {
+            anyhow::bail!(
+                "Encoded input failed for second time. Bailing: {:?}",
+                encoded_input
+            );
+        }
+    }
 
     let tokens = match state.model_type {
         fish_speech_core::models::vqgan::config::WhichModel::Fish1_5 => tokens,

--- a/server/lib/handlers/speech.rs
+++ b/server/lib/handlers/speech.rs
@@ -8,9 +8,7 @@ use candle_core::{DType, Tensor, D};
 use fish_speech_core::audio::{functional::resample, wav::write_pcm_as_wav};
 use fish_speech_core::models::text2semantic::utils::encode::EncodedChunks;
 use fish_speech_core::models::text2semantic::utils::{
-    encode::encode_chunks,
-    generate::{generate_blocking, generate_blocking_with_hidden},
-    sample::SamplingArgs,
+    encode::encode_chunks, generate::generate_blocking_with_hidden, sample::SamplingArgs,
     text::preprocess_text,
 };
 use serde::{Deserialize, Serialize};
@@ -80,7 +78,7 @@ async fn generate_pcm_chunk(
         temp: state.temp,
         top_p: state.top_p,
         top_k: 256,
-        repetition_penalty: 1.35,
+        repetition_penalty: 1.3,
     };
 
     let (semantic_tokens, _) = server_lm_generate_blocking(


### PR DESCRIPTION
This PR adds:
- Earlier aggressive chunking
- Random seed for generation

Closes #30, #28.

Note that I actually tried keeping previous generations resident in the prompt. While this did work, it ALSO caused early errors to propagate over the full sample, and slowed down generation by 15-30%. Unless anyone is really bothered by edge artifacts, I'm not going to support this, sorry.